### PR TITLE
[FIX] Correção de header incorreto na documentação do easy-docs

### DIFF
--- a/src/dgs-components/easy-docs/first-component.md
+++ b/src/dgs-components/easy-docs/first-component.md
@@ -151,7 +151,7 @@ Acesse o link `http://localhost:6006/` e veja o seu componente.
 Você deve enviar no Header na requisição o formato que deseja o documento
 
 - application/pdf
-- application/html
+- text/html
 
 O Easy Docs pode retornar dessas 2 formas, baseado no header enviado.
 

--- a/src/en/dgs-components/easy-docs/first-component.md
+++ b/src/en/dgs-components/easy-docs/first-component.md
@@ -151,7 +151,7 @@ Access the link `http://localhost:6006/` and see your component.
 You must send the desired document format in the Header of the request:
 
 - application/pdf
-- application/html
+- text/html
 
 Easy Docs can return these two formats based on the header sent.
 

--- a/src/es/dgs-components/easy-docs/first-component.md
+++ b/src/es/dgs-components/easy-docs/first-component.md
@@ -150,7 +150,7 @@ Accede al enlace `http://localhost:6006/` y ve tu componente.
 Debes enviar en el Header de la solicitud el formato que deseas para el documento:
 
 - application/pdf
-- application/html
+- text/html
 
 Easy Docs puede retornar en cualquiera de estos dos formatos, basado en el header enviado.
 


### PR DESCRIPTION
**Problema:**
Ao seguir a documentação de utilização do easy-docs, o seguinte erro ocorre quando tentamos passar o cabeçalho atual da documentação: 

![image](https://github.com/db1group/dgs-engineer-guide/assets/137503892/afc3726c-9bf2-4af1-a904-f28daede88ce)

**Correção:** Sendo assim, foi realizado o ajuste na documentação com o cabeçalho correto solicitado pela própria aplicação.