### PR TITLE
fix: disable cleanUrls for S3 compatibility

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -6,7 +6,7 @@ import { pt } from "./pt";
 export default defineConfig({
   title: "Engineering Guide",
   srcDir: "src",
-  cleanUrls: true,
+  cleanUrls: false,
   head: [
     [
       "link",


### PR DESCRIPTION
Alterado cleanUrls de true para false no config.mts.

O S3 não consegue resolver rotas sem extensão .html. Com cleanUrls: true, URLs como /guia/introducao retornam 404 no S3, pois ele procura o arquivo exato no bucket e não encontra sem a extensão. Desabilitando a opção, as URLs voltam ao formato /guia/introducao.html, que o S3 resolve corretamente.